### PR TITLE
js: reload: react magic proof of concept

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,6 +10,10 @@
     = javascript_include_tag "application", "data-turbolinks-track" => true
     - if Rails.env == 'development'
       = javascript_include_tag "try", "data-turbolinks-track" => true
+    = javascript_include_tag "http://fb.me/react-0.10.0.js"
+    = javascript_include_tag "http://facebook.github.io/react/js/JSXTransformer.js"
+    = javascript_include_tag "http://facebook.github.io/react/js/html-jsx-lib.js"
+
     = csrf_meta_tags
   %body{data: (@body_data || {})}
     .container
@@ -35,6 +39,6 @@
 
       %div#application{data: {env: Rails.env}}
 
-      = yield 
+        = yield 
 
 


### PR DESCRIPTION
as requested:
- reloads the page with react's diff magic, but without react templates
- is still crazy mad:
  - HTML is converted to JSX, which is converted to JS functions, which creates a virtual DOM, which is then rendered into the container element of the real DOM
  - this happens on page load and every ajax 'refresh' event
